### PR TITLE
Strip stray whitespace at start or end from names

### DIFF
--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -31,7 +31,7 @@ def test_get_proposals_and_sample_for_specific_id_on_ymir_instrument():
         )
         assert result.id == "471120"
         assert result.users == [
-            ("jonathan ", "Taylor"),
+            ("jonathan", "Taylor"),
             ("Johan", "Andersson"),
         ]
         assert result.proposer == ("Fredrik", "Bolmsten")

--- a/tests/test_extracting_user_info_from_proposal.py
+++ b/tests/test_extracting_user_info_from_proposal.py
@@ -25,6 +25,20 @@ def test_extracting_users_when_users_not_present_gives_no_users():
     assert len(results) == 0
 
 
+def test_extracting_users_stray_whitespace_removed():
+    proposal = {
+        "id": 123,
+        "title": "Title filled out correctly",
+        "users": [
+            {"firstname": " Ralf ", "lastname": " Fields "},
+        ],
+        "proposer": {"firstname": "Alberto", "lastname": "Accountant"},
+    }
+
+    results = extract_users(proposal)
+    assert results[0] == ("Ralf", "Fields")
+
+
 def test_extracting_users_when_user_missing_firstname_or_lastname_inserts_blanks():
     # Not sure if is possible, but...
     proposal_missing_parts = {
@@ -55,3 +69,17 @@ def test_extracting_proposer_when_not_present_gives_none():
 
     result = extract_proposer(proposal_no_proposer)
     assert result is None
+
+
+def test_extracting_proposer_stray_whitespace_removed():
+    proposal = {
+        "id": 123,
+        "title": "Title filled out correctly",
+        "users": [
+            {"firstname": "Ralf", "lastname": "Fields"},
+        ],
+        "proposer": {"firstname": " Alberto ", "lastname": " Accountant "},
+    }
+
+    result = extract_proposer(proposal)
+    assert result == ("Alberto", "Accountant")

--- a/tests/test_proposl_system.py
+++ b/tests/test_proposl_system.py
@@ -55,7 +55,7 @@ def test_gets_proposal_information():
     )
     assert proposals[KNOWN_PROPOSAL_ID].id == KNOWN_PROPOSAL_ID
     assert proposals[KNOWN_PROPOSAL_ID].users == [
-        ("jonathan ", "Taylor"),
+        ("jonathan", "Taylor"),
         ("Johan", "Andersson"),
     ]
     assert proposals[KNOWN_PROPOSAL_ID].proposer == ("Fredrik", "Bolmsten")

--- a/yuos_query/data_extractors.py
+++ b/yuos_query/data_extractors.py
@@ -4,8 +4,8 @@ from yuos_query.data_classes import SampleInfo
 def extract_proposer(proposal):
     if "proposer" in proposal:
         proposer = (
-            proposal["proposer"].get("firstname", ""),
-            proposal["proposer"].get("lastname", ""),
+            proposal["proposer"].get("firstname", "").strip(),
+            proposal["proposer"].get("lastname", "").strip(),
         )
     else:
         proposer = None
@@ -15,7 +15,8 @@ def extract_proposer(proposal):
 def extract_users(proposal):
     if "users" in proposal:
         return [
-            (x.get("firstname", ""), x.get("lastname", "")) for x in proposal["users"]
+            (x.get("firstname", "").strip(), x.get("lastname", "").strip())
+            for x in proposal["users"]
         ]
     return []
 


### PR DESCRIPTION
Noticed a user name from the proposal system which had some stray whitespace at the end.
Really the proposal system shouldn't allow this, but we can fix this our end anyway.