### PR TITLE
Organise proposals by fed id

### DIFF
--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -51,3 +51,18 @@ def test_get_proposals_and_sample_for_specific_id_on_ymir_instrument():
         assert result.samples[2].number == 1
         assert result.samples[2].density == (0, "g/cm*3")
         assert result.samples[2].mass_or_volume == (0, "µg")
+
+
+@pytest.mark.skipif(
+    SKIP_TEST, reason="no token supplied for testing against real system"
+)
+def test_get_proposals_for_specific_fed_id_on_ymir_instrument():
+    with TemporaryDirectory() as directory:
+        client = YuosClient(
+            SERVER_URL, YUOS_TOKEN, "YMIR", os.path.join(directory, "cache.json")
+        )
+
+        results = client.proposals_for_user("jonathantaylor")
+
+        assert len(results) == 3
+        assert {p.id for p in results} == {"471120", "871067", "035455"}

--- a/integration_tests/test_end_to_end.py
+++ b/integration_tests/test_end_to_end.py
@@ -31,10 +31,10 @@ def test_get_proposals_and_sample_for_specific_id_on_ymir_instrument():
         )
         assert result.id == "471120"
         assert result.users == [
-            ("jonathan", "Taylor"),
-            ("Johan", "Andersson"),
+            ("jonathan", "Taylor", "jonathantaylor"),
+            ("Johan", "Andersson", "johanandersson"),
         ]
-        assert result.proposer == ("Fredrik", "Bolmsten")
+        assert result.proposer == ("Fredrik", "Bolmsten", "fredrikbolmsten")
         assert len(result.samples) == 3
         assert result.samples[0].name == ""
         assert result.samples[0].formula == "Yb3Ga5O12"

--- a/tests/test_arrange_by_fed_id.py
+++ b/tests/test_arrange_by_fed_id.py
@@ -1,0 +1,10 @@
+from tests.test_yuos_client import VALID_PROPOSAL_DATA
+from yuos_query.data_extractors import arrange_by_user
+
+
+def test_can_organise_proposals_by_fed_id():
+    proposals_by_users = arrange_by_user(VALID_PROPOSAL_DATA)
+    result = proposals_by_users["jonathantaylor"]
+
+    assert len(result) == 2
+    assert {p.id for p in result} == {"471120", "871067"}

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -4,20 +4,22 @@ from tempfile import TemporaryDirectory
 import pytest
 
 from tests.test_yuos_client import VALID_PROPOSAL_DATA
+from yuos_query.data_classes import ProposalInfo
 from yuos_query.exceptions import ExportCacheException, ImportCacheException
 from yuos_query.file_cache import FileCache
 
 
-def test_exporting_data_to_json_from_cache():
+def test_exporting_and_importing_data_to_and_from_cache():
     with TemporaryDirectory() as directory:
         cache = FileCache(os.path.join(directory, "test_filename.json"))
         cache.update(VALID_PROPOSAL_DATA)
 
-        cache.export_to_json()
+        cache.export_to_file()
         cache.clear_cache()
-        cache.import_from_json()
+        cache.import_from_file()
 
         assert cache.proposals["471120"].id == VALID_PROPOSAL_DATA["471120"].id
+        assert len(cache.proposals_by_fed_id["jonathantaylor"]) == 2
 
 
 def test_importing_proposals_from_file_if_does_not_exist():
@@ -26,7 +28,7 @@ def test_importing_proposals_from_file_if_does_not_exist():
         cache.update(VALID_PROPOSAL_DATA)
 
         with pytest.raises(ImportCacheException):
-            cache.import_from_json()
+            cache.import_from_file()
 
 
 def test_importing_proposals_from_file_with_non_json_data():
@@ -39,14 +41,19 @@ def test_importing_proposals_from_file_with_non_json_data():
             file.write(":: IRRELEVANT DATA ::")
 
         with pytest.raises(ImportCacheException):
-            cache.import_from_json()
+            cache.import_from_file()
 
 
 def test_exporting_data_from_cache_with_invalid_data():
-    cache = FileCache("test_filename.json")
-    CANNOT_BE_SERIALIZED = type
+    cache = FileCache(":: filepath ::")
+    # Put something in ProposalInfo that cannot be serialised
+    CANNOT_BE_SERIALIZED = {
+        "a": ProposalInfo(
+            type, ":: title ::", proposer=None, users=[], db_id=1, samples=[]
+        )
+    }
 
     cache.update(CANNOT_BE_SERIALIZED)
 
     with pytest.raises(ExportCacheException):
-        cache.export_to_json()
+        cache.export_to_file()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -45,15 +45,20 @@ def test_importing_proposals_from_file_with_non_json_data():
 
 
 def test_exporting_data_from_cache_with_invalid_data():
-    cache = FileCache(":: filepath ::")
-    # Put something in ProposalInfo that cannot be serialised
-    CANNOT_BE_SERIALIZED = {
-        "a": ProposalInfo(
-            type, ":: title ::", proposer=None, users=[], db_id=1, samples=[]
-        )
-    }
+    filename = "test_filename.json"
+    with TemporaryDirectory() as directory:
+        cache = FileCache(filename)
+        # Put something in ProposalInfo that cannot be serialised
+        CANNOT_BE_SERIALIZED = {
+            "a": ProposalInfo(
+                type, ":: title ::", proposer=None, users=[], db_id=123, samples=[]
+            )
+        }
 
-    cache.update(CANNOT_BE_SERIALIZED)
+        cache.update(CANNOT_BE_SERIALIZED)
 
-    with pytest.raises(ExportCacheException):
-        cache.export_to_file()
+        with pytest.raises(ExportCacheException):
+            cache.export_to_file()
+
+        # Should not leave a file behind
+        assert not os.path.exists(os.path.join(directory, filename))

--- a/tests/test_extracting_user_info_from_proposal.py
+++ b/tests/test_extracting_user_info_from_proposal.py
@@ -36,7 +36,7 @@ def test_extracting_users_stray_whitespace_removed():
     }
 
     results = extract_users(proposal)
-    assert results[0] == ("Ralf", "Fields")
+    assert results[0] == ("Ralf", "Fields", "ralffields")
 
 
 def test_extracting_users_when_user_missing_firstname_or_lastname_inserts_blanks():
@@ -53,8 +53,8 @@ def test_extracting_users_when_user_missing_firstname_or_lastname_inserts_blanks
 
     results = extract_users(proposal_missing_parts)
     assert len(results) == 2
-    assert ("Ralf", "") in results
-    assert ("", "Fields") in results
+    assert ("Ralf", "", "ralf") in results
+    assert ("", "Fields", "fields") in results
 
 
 def test_extracting_proposer_when_not_present_gives_none():
@@ -82,4 +82,4 @@ def test_extracting_proposer_stray_whitespace_removed():
     }
 
     result = extract_proposer(proposal)
-    assert result == ("Alberto", "Accountant")
+    assert result == ("Alberto", "Accountant", "albertoaccountant")

--- a/tests/test_proposal_requester.py
+++ b/tests/test_proposal_requester.py
@@ -55,10 +55,14 @@ def test_gets_proposal_information():
     )
     assert proposals[KNOWN_PROPOSAL_ID].id == KNOWN_PROPOSAL_ID
     assert proposals[KNOWN_PROPOSAL_ID].users == [
-        ("jonathan", "Taylor"),
-        ("Johan", "Andersson"),
+        ("jonathan", "Taylor", "jonathantaylor"),
+        ("Johan", "Andersson", "johanandersson"),
     ]
-    assert proposals[KNOWN_PROPOSAL_ID].proposer == ("Fredrik", "Bolmsten")
+    assert proposals[KNOWN_PROPOSAL_ID].proposer == (
+        "Fredrik",
+        "Bolmsten",
+        "fredrikbolmsten",
+    )
     assert len(proposals[KNOWN_PROPOSAL_ID].samples) == 3
     assert proposals[KNOWN_PROPOSAL_ID].samples[0].name == ""
     assert proposals[KNOWN_PROPOSAL_ID].samples[0].formula == "Yb3Ga5O12"

--- a/tests/test_yuos_client.py
+++ b/tests/test_yuos_client.py
@@ -17,8 +17,11 @@ VALID_PROPOSAL_DATA = {
     "471120": ProposalInfo(
         id="471120",
         title="The magnetic field dependence of the director state in the quantum spin hyperkagome compound Yb3Ga5O12",
-        proposer=("Fredrik", "Bolmsten"),
-        users=[("jonathan", "Taylor"), ("Johan", "Andersson")],
+        proposer=("Fredrik", "Bolmsten", "fredrikbolmsten"),
+        users=[
+            ("jonathan", "Taylor", "jonathantaylor"),
+            ("Johan", "Andersson", "johanandersson"),
+        ],
         db_id=169,
         samples=[
             SampleInfo(
@@ -40,8 +43,11 @@ VALID_PROPOSAL_DATA = {
     "871067": ProposalInfo(
         id="871067",
         title="The Structure of Cheese Under Pressure",
-        proposer=("Andrew", "Jackson"),
-        users=[("jonathan", "Taylor"), ("Caroline", "Curfs")],
+        proposer=("Andrew", "Jackson", "andrewjackson"),
+        users=[
+            ("jonathan", "Taylor", "jonathantaylor"),
+            ("Caroline", "Curfs", "carolinecurfs"),
+        ],
         db_id=242,
         samples=[],
     ),
@@ -72,7 +78,7 @@ class TestYuosClient:
 
         self.system.get_proposals_for_instrument.assert_called_once()
         self.cache.update.assert_called_once()
-        self.cache.export_to_json.assert_called_once()
+        self.cache.export_to_file.assert_called_once()
 
     def test_on_refreshing_cache_proposal_system_called_and_cache_updated(self):
         _ = self.create_client()
@@ -107,30 +113,32 @@ class TestYuosClient:
         )
         assert proposal_info.id == "471120"
         assert proposal_info.users == [
-            ("jonathan", "Taylor"),
-            ("Johan", "Andersson"),
+            ("jonathan", "Taylor", "jonathantaylor"),
+            ("Johan", "Andersson", "johanandersson"),
         ]
-        assert proposal_info.proposer == ("Fredrik", "Bolmsten")
+        assert proposal_info.proposer == ("Fredrik", "Bolmsten", "fredrikbolmsten")
 
     def test_if_proposal_system_unavailable_load_from_cache(self):
         self.system.get_proposals_for_instrument.side_effect = ServerException("oops")
 
         _ = self.create_client()
-        self.cache.import_from_json.assert_called_once()
+        self.cache.import_from_file.assert_called_once()
 
     def test_if_proposal_system_unavailable_and_load_from_cache_raises(self):
         self.system.get_proposals_for_instrument.side_effect = ServerException("oops")
-        self.cache.import_from_json.side_effect = ImportCacheException("oops")
+        self.cache.import_from_file.side_effect = ImportCacheException("oops")
 
         with pytest.raises(DataUnavailableException):
             _ = self.create_client()
 
-    def test_if_proposal_system_unavailable_and_cache_not_empty_then_dont_import(self):
+    def test_if_proposal_system_unavailable_and_cache_not_empty_then_do_not_import(
+        self,
+    ):
         self.system.get_proposals_for_instrument.side_effect = ServerException("oops")
         self.cache.is_empty.return_value = False
 
         _ = self.create_client()
-        self.cache.import_from_json.assert_not_called()
+        self.cache.import_from_file.assert_not_called()
 
     def test_on_refresh_proposal_system_called_and_cache_updated(self):
         client = self.create_client()
@@ -141,11 +149,12 @@ class TestYuosClient:
 
         self.system.get_proposals_for_instrument.assert_called_once()
         self.cache.update.assert_called_once()
-        self.cache.export_to_json.assert_called_once()
+        self.cache.export_to_file.assert_called_once()
 
     def test_can_get_proposals_by_fed_id(self):
         cache = FileCache(":: filepath ::")
         cache.update(VALID_PROPOSAL_DATA)
+        self.system.get_proposals_for_instrument.return_value = VALID_PROPOSAL_DATA
 
         client = self.create_client(cache)
         proposals = client.proposals_for_user("jonathantaylor")
@@ -154,5 +163,11 @@ class TestYuosClient:
         assert {p.id for p in proposals} == {"471120", "871067"}
 
     def test_unrecognised_fed_id(self):
-        # TODO
-        pass
+        cache = FileCache(":: filepath ::")
+        cache.update(VALID_PROPOSAL_DATA)
+        self.system.get_proposals_for_instrument.return_value = VALID_PROPOSAL_DATA
+
+        client = self.create_client(cache)
+        proposals = client.proposals_for_user("not_a_fed_id")
+
+        assert len(proposals) == 0

--- a/tests/test_yuos_client.py
+++ b/tests/test_yuos_client.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 
-from yuos_query.data_classes import ProposalInfo, SampleInfo
+from yuos_query.data_classes import ProposalInfo, SampleInfo, User
 from yuos_query.exceptions import (
     DataUnavailableException,
     ImportCacheException,
@@ -17,10 +17,10 @@ VALID_PROPOSAL_DATA = {
     "471120": ProposalInfo(
         id="471120",
         title="The magnetic field dependence of the director state in the quantum spin hyperkagome compound Yb3Ga5O12",
-        proposer=("Fredrik", "Bolmsten", "fredrikbolmsten"),
+        proposer=User("Fredrik", "Bolmsten", "fredrikbolmsten"),
         users=[
-            ("jonathan", "Taylor", "jonathantaylor"),
-            ("Johan", "Andersson", "johanandersson"),
+            User("jonathan", "Taylor", "jonathantaylor"),
+            User("Johan", "Andersson", "johanandersson"),
         ],
         db_id=169,
         samples=[
@@ -43,10 +43,10 @@ VALID_PROPOSAL_DATA = {
     "871067": ProposalInfo(
         id="871067",
         title="The Structure of Cheese Under Pressure",
-        proposer=("Andrew", "Jackson", "andrewjackson"),
+        proposer=User("Andrew", "Jackson", "andrewjackson"),
         users=[
-            ("jonathan", "Taylor", "jonathantaylor"),
-            ("Caroline", "Curfs", "carolinecurfs"),
+            User("jonathan", "Taylor", "jonathantaylor"),
+            User("Caroline", "Curfs", "carolinecurfs"),
         ],
         db_id=242,
         samples=[],

--- a/tests/test_yuos_client.py
+++ b/tests/test_yuos_client.py
@@ -60,7 +60,7 @@ class TestYuosClient:
         self.cache = mock.create_autospec(FileCache)
         self.system = mock.create_autospec(ProposalRequester)
 
-    def create_client(self, cache=None):
+    def create_client(self, cache=None, update_cache=True):
         if not cache:
             cache = self.cache
 
@@ -69,6 +69,7 @@ class TestYuosClient:
             ":: token ::",
             "YMIR",
             ":: file ::",
+            update_cache=update_cache,
             cache=cache,
             system=self.system,
         )
@@ -156,7 +157,7 @@ class TestYuosClient:
         cache.update(VALID_PROPOSAL_DATA)
         self.system.get_proposals_for_instrument.return_value = VALID_PROPOSAL_DATA
 
-        client = self.create_client(cache)
+        client = self.create_client(cache, update_cache=False)
         proposals = client.proposals_for_user("jonathantaylor")
 
         assert len(proposals) == 2
@@ -167,7 +168,7 @@ class TestYuosClient:
         cache.update(VALID_PROPOSAL_DATA)
         self.system.get_proposals_for_instrument.return_value = VALID_PROPOSAL_DATA
 
-        client = self.create_client(cache)
+        client = self.create_client(cache, update_cache=False)
         proposals = client.proposals_for_user("not_a_fed_id")
 
         assert len(proposals) == 0

--- a/tests/test_yuos_client.py
+++ b/tests/test_yuos_client.py
@@ -18,7 +18,7 @@ VALID_PROPOSAL_DATA = {
         id="471120",
         title="The magnetic field dependence of the director state in the quantum spin hyperkagome compound Yb3Ga5O12",
         proposer=("Fredrik", "Bolmsten"),
-        users=[("jonathan ", "Taylor"), ("Johan", "Andersson")],
+        users=[("jonathan", "Taylor"), ("Johan", "Andersson")],
         db_id=169,
         samples=[
             SampleInfo(
@@ -41,7 +41,7 @@ VALID_PROPOSAL_DATA = {
         id="871067",
         title="The Structure of Cheese Under Pressure",
         proposer=("Andrew", "Jackson"),
-        users=[("jonathan ", "Taylor"), ("Caroline", "Curfs")],
+        users=[("jonathan", "Taylor"), ("Caroline", "Curfs")],
         db_id=242,
         samples=[],
     ),
@@ -54,13 +54,16 @@ class TestYuosClient:
         self.cache = mock.create_autospec(FileCache)
         self.system = mock.create_autospec(ProposalRequester)
 
-    def create_client(self):
+    def create_client(self, cache=None):
+        if not cache:
+            cache = self.cache
+
         return YuosClient(
             ":: url ::",
             ":: token ::",
             "YMIR",
             ":: file ::",
-            cache=self.cache,
+            cache=cache,
             system=self.system,
         )
 
@@ -104,7 +107,7 @@ class TestYuosClient:
         )
         assert proposal_info.id == "471120"
         assert proposal_info.users == [
-            ("jonathan ", "Taylor"),
+            ("jonathan", "Taylor"),
             ("Johan", "Andersson"),
         ]
         assert proposal_info.proposer == ("Fredrik", "Bolmsten")
@@ -139,3 +142,17 @@ class TestYuosClient:
         self.system.get_proposals_for_instrument.assert_called_once()
         self.cache.update.assert_called_once()
         self.cache.export_to_json.assert_called_once()
+
+    def test_can_get_proposals_by_fed_id(self):
+        cache = FileCache(":: filepath ::")
+        cache.update(VALID_PROPOSAL_DATA)
+
+        client = self.create_client(cache)
+        proposals = client.proposals_for_user("jonathantaylor")
+
+        assert len(proposals) == 2
+        assert {p.id for p in proposals} == {"471120", "871067"}
+
+    def test_unrecognised_fed_id(self):
+        # TODO
+        pass

--- a/yuos_query/data_classes.py
+++ b/yuos_query/data_classes.py
@@ -17,8 +17,8 @@ ProposalInfo = NamedTuple(
     (
         ("id", str),
         ("title", str),
-        ("proposer", Tuple[str, str]),
-        ("users", List[Tuple[str, str]]),
+        ("proposer", Tuple[str, str, str]),
+        ("users", List[Tuple[str, str, str]]),
         ("db_id", int),
         ("samples", List[SampleInfo]),
     ),

--- a/yuos_query/data_classes.py
+++ b/yuos_query/data_classes.py
@@ -11,6 +11,15 @@ SampleInfo = NamedTuple(
     ),
 )
 
+User = NamedTuple(
+    "User",
+    (
+        ("firstname", str),
+        ("lastname", str),
+        ("fed_id", str),
+    ),
+)
+
 
 ProposalInfo = NamedTuple(
     "ProposalInfo",
@@ -18,7 +27,7 @@ ProposalInfo = NamedTuple(
         ("id", str),
         ("title", str),
         ("proposer", Tuple[str, str, str]),
-        ("users", List[Tuple[str, str, str]]),
+        ("users", List[User]),
         ("db_id", int),
         ("samples", List[SampleInfo]),
     ),

--- a/yuos_query/data_extractors.py
+++ b/yuos_query/data_extractors.py
@@ -1,23 +1,38 @@
 from yuos_query.data_classes import SampleInfo
 
 
+def _generate_fed_id(firstname, lastname):
+    # TODO: this is a hack to generate something like a fed ID while
+    # we wait for the real fed IDs to appear in the proposal system
+    return f"{firstname}{lastname}".lower()
+
+
 def extract_proposer(proposal):
+    def _extract_name(user):
+        first = user.get("firstname", "").strip()
+        last = user.get("lastname", "").strip()
+        return first, last, _generate_fed_id(first, last)
+
     if "proposer" in proposal:
-        proposer = (
-            proposal["proposer"].get("firstname", "").strip(),
-            proposal["proposer"].get("lastname", "").strip(),
-        )
+        proposer = _extract_name(proposal["proposer"])
     else:
         proposer = None
     return proposer
 
 
 def extract_users(proposal):
+    """
+    :param proposal: The proposal
+    :return: A tuple of first name, last name, fed id
+    """
+
+    def _extract_name(user):
+        first = user.get("firstname", "").strip()
+        last = user.get("lastname", "").strip()
+        return first, last, _generate_fed_id(first, last)
+
     if "users" in proposal:
-        return [
-            (x.get("firstname", "").strip(), x.get("lastname", "").strip())
-            for x in proposal["users"]
-        ]
+        return [_extract_name(user) for user in proposal["users"]]
     return []
 
 
@@ -90,7 +105,7 @@ def arrange_by_user(proposals_by_id):
     proposals_by_users = {}
     for proposal_id, proposal in proposals_by_id.items():
         for user in proposal.users:
-            fed_id = f"{user[0]}{user[1]}".lower()
+            fed_id = user[2]
             for_user = proposals_by_users.get(fed_id, [])
             for_user.append(proposal)
             proposals_by_users[fed_id] = for_user

--- a/yuos_query/data_extractors.py
+++ b/yuos_query/data_extractors.py
@@ -1,4 +1,4 @@
-from yuos_query.data_classes import SampleInfo
+from yuos_query.data_classes import SampleInfo, User
 
 
 def _generate_fed_id(firstname, lastname):
@@ -11,7 +11,7 @@ def extract_proposer(proposal):
     def _extract_name(user):
         first = user.get("firstname", "").strip()
         last = user.get("lastname", "").strip()
-        return first, last, _generate_fed_id(first, last)
+        return User(first, last, _generate_fed_id(first, last))
 
     if "proposer" in proposal:
         proposer = _extract_name(proposal["proposer"])
@@ -29,7 +29,7 @@ def extract_users(proposal):
     def _extract_name(user):
         first = user.get("firstname", "").strip()
         last = user.get("lastname", "").strip()
-        return first, last, _generate_fed_id(first, last)
+        return User(first, last, _generate_fed_id(first, last))
 
     if "users" in proposal:
         return [_extract_name(user) for user in proposal["users"]]

--- a/yuos_query/data_extractors.py
+++ b/yuos_query/data_extractors.py
@@ -84,3 +84,15 @@ def extract_relevant_sample_info(data):
     for sample in data:
         results.append(_extract_sample_data(sample))
     return results
+
+
+def arrange_by_user(proposals_by_id):
+    proposals_by_users = {}
+    for proposal_id, proposal in proposals_by_id.items():
+        for user in proposal.users:
+            fed_id = f"{user[0]}{user[1]}".lower()
+            for_user = proposals_by_users.get(fed_id, [])
+            for_user.append(proposal)
+            proposals_by_users[fed_id] = for_user
+
+    return proposals_by_users

--- a/yuos_query/file_cache.py
+++ b/yuos_query/file_cache.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from json.decoder import JSONDecodeError
 
 from yuos_query.data_extractors import arrange_by_user
 from yuos_query.exceptions import ExportCacheException, ImportCacheException
@@ -19,30 +18,29 @@ class FileCache:
         self.proposals = deepcopy(proposals)
         self.proposals_by_fed_id = arrange_by_user(self.proposals)
 
-    def export_to_json(self):
+    def export_to_file(self):
         try:
             with open(self.cache_filepath, "w") as file:
                 file.write(serialise_proposals_to_json(self.proposals))
         except Exception as error:
             raise ExportCacheException(f"Export exception: {error}")
 
-    def import_from_json(self):
+    def import_from_file(self):
         try:
             with open(self.cache_filepath, "r") as file:
-                self.proposals = deserialise_proposals_from_json(file.read())
+                self.update(deserialise_proposals_from_json(file.read()))
         except FileNotFoundError as error:
             raise ImportCacheException(
-                f"File not found: {self.cache_filepath}"
-            ) from error
-        except JSONDecodeError as error:
-            raise ImportCacheException(
-                f"Could not deserialise data from file: {self.cache_filepath}"
+                f"Cache file ({self.cache_filepath}) not found"
             ) from error
         except Exception as error:
-            raise ImportCacheException(f"Import exception: {error}") from error
+            raise ImportCacheException(
+                f"Could not extract data from cache file ({self.cache_filepath}): {error}"
+            ) from error
 
     def clear_cache(self):
         self.proposals = {}
+        self.proposals_by_fed_id = {}
 
     def is_empty(self):
         return len(self.proposals) == 0

--- a/yuos_query/file_cache.py
+++ b/yuos_query/file_cache.py
@@ -20,8 +20,9 @@ class FileCache:
 
     def export_to_file(self):
         try:
+            json = serialise_proposals_to_json(self.proposals)
             with open(self.cache_filepath, "w") as file:
-                file.write(serialise_proposals_to_json(self.proposals))
+                file.write(json)
         except Exception as error:
             raise ExportCacheException(f"Export exception: {error}")
 

--- a/yuos_query/file_cache.py
+++ b/yuos_query/file_cache.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from json.decoder import JSONDecodeError
 
+from yuos_query.data_extractors import arrange_by_user
 from yuos_query.exceptions import ExportCacheException, ImportCacheException
 from yuos_query.utils import (
     deserialise_proposals_from_json,
@@ -12,9 +13,11 @@ class FileCache:
     def __init__(self, cache_filepath):
         self.cache_filepath = cache_filepath
         self.proposals = {}
+        self.proposals_by_fed_id = {}
 
     def update(self, proposals):
         self.proposals = deepcopy(proposals)
+        self.proposals_by_fed_id = arrange_by_user(self.proposals)
 
     def export_to_json(self):
         try:

--- a/yuos_query/utils.py
+++ b/yuos_query/utils.py
@@ -4,7 +4,6 @@ from yuos_query.data_classes import ProposalInfo, SampleInfo
 
 
 def serialise_proposals_to_json(proposals):
-
     json_proposals = {}
     for id, proposal in proposals.items():
         json_proposal = proposal._asdict()

--- a/yuos_query/yuos_client.py
+++ b/yuos_query/yuos_client.py
@@ -31,6 +31,8 @@ class YuosClient:
         return self.cache.proposals.get(converted_id)
 
     def proposals_for_user(self, fed_id: str) -> List[ProposalInfo]:
+        if fed_id not in self.cache.proposals_by_fed_id:
+            return []
         return self.cache.proposals_by_fed_id[fed_id]
 
     def _validate_proposal_id(self, proposal_id: str) -> str:
@@ -45,11 +47,11 @@ class YuosClient:
         try:
             proposals = self.system.get_proposals_for_instrument(self.instrument)
             self.cache.update(proposals)
-            self.cache.export_to_json()
+            self.cache.export_to_file()
         except ServerException:
             try:
                 if self.cache.is_empty():
-                    self.cache.import_from_json()
+                    self.cache.import_from_file()
             except ImportCacheException as error:
                 raise DataUnavailableException(
                     "Proposal system and Cache unavailable"

--- a/yuos_query/yuos_client.py
+++ b/yuos_query/yuos_client.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 
 from yuos_query.data_classes import ProposalInfo
 from yuos_query.exceptions import (
@@ -29,6 +29,9 @@ class YuosClient:
         """
         converted_id = self._validate_proposal_id(proposal_id)
         return self.cache.proposals.get(converted_id)
+
+    def proposals_for_user(self, fed_id: str) -> List[ProposalInfo]:
+        return self.cache.proposals_by_fed_id[fed_id]
 
     def _validate_proposal_id(self, proposal_id: str) -> str:
         # Does proposal_id conform to the expected pattern?

--- a/yuos_query/yuos_client.py
+++ b/yuos_query/yuos_client.py
@@ -13,12 +13,22 @@ from yuos_query.proposal_system import ProposalRequester
 
 
 class YuosClient:
-    def __init__(self, url, token, instrument, cache_filepath, cache=None, system=None):
+    def __init__(
+        self,
+        url,
+        token,
+        instrument,
+        cache_filepath,
+        update_cache=True,
+        cache=None,
+        system=None,
+    ):
         self.instrument = instrument
         self.cache = cache if cache else FileCache(cache_filepath)
         self.system = system if system else ProposalRequester(url, token)
 
-        self.update_cache()
+        if update_cache:
+            self.update_cache()
 
     def proposal_by_id(self, proposal_id: str) -> Optional[ProposalInfo]:
         """


### PR DESCRIPTION
Allows the proposals to be found by fed id.
Currently we don't have fed ids in the proposal system so this creates fake ones as a proof of concept.