### PR TITLE
Specify build dependencies in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    "setuptools>=45",
+    "gql>=3.0.0",
+    "requests>=2.27.1",
+    "requests-toolbelt>=0.9.1"
+    ]


### PR DESCRIPTION
When adding the repository as a source to `uv`,

``` toml
[tool.uv.sources]
yuos-query = { git = "https://github.com/ess-dmsc/yuos_query", tag="v0.1.22"}
```

then `uv` will warn about unspecified build dependencies. By naming these in the `pyproject.toml`, `yuos_query` can be built by `uv` from source.